### PR TITLE
Add BUILD_DIR variable to .ycm_extra_conf.py

### DIFF
--- a/.vim/.ycm_extra_conf.py
+++ b/.vim/.ycm_extra_conf.py
@@ -5,6 +5,12 @@ import logging
 import ycm_core
 import re
 
+# Directory where to find the file 'compile_commands.json' for out-of-source
+# builds.
+# This is not necessary to set BUILD_DIR if the build directory is called
+# `build` and is either inside the sources or at the same level.
+BUILD_DIR = ''
+
 BASE_FLAGS = [
         '-Wall',
         '-Wextra',
@@ -161,7 +167,11 @@ def FlagsForCompilationDatabase(root, filename):
         return None
 
 def FlagsForFile(filename):
-    root = os.path.realpath(filename);
+    root = ''
+    if BUILD_DIR:
+        root = os.path.realpath(BUILD_DIR)
+    if not os.path.exists(root + '/compile_commands.json'):
+        root = os.path.realpath(filename)
     compilation_db_flags = FlagsForCompilationDatabase(root, filename)
     if compilation_db_flags:
         final_flags = compilation_db_flags


### PR DESCRIPTION
BUILD_DIR allows to look for the compile_commands.json file
for out-of-source builds, when the build directory is not at the same
level as the source directory.

Originally #7, which was closed because it included changes in untouched lines.