### PR TITLE
allow .clang_complete file placed in different dir

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -57,3 +57,6 @@ alias gg='git grep'
 
 # Fast diff for large files.
 alias fdiff='diff --speed-large-files'
+
+# Simple HTTP server.
+alias serve='python3 -m http.server'

--- a/.aliases
+++ b/.aliases
@@ -57,6 +57,3 @@ alias gg='git grep'
 
 # Fast diff for large files.
 alias fdiff='diff --speed-large-files'
-
-# Simple HTTP server.
-alias serve='python3 -m http.server'

--- a/.config/fish/functions/dview.fish
+++ b/.config/fish/functions/dview.fish
@@ -1,0 +1,5 @@
+function dview -d "View dot file as PDF"
+    set -lx output "$argv[1].pdf"
+    dot $argv[1] -T pdf -o $output
+    open $output
+end

--- a/.config/fish/functions/gscp.fish
+++ b/.config/fish/functions/gscp.fish
@@ -1,0 +1,4 @@
+function gscp -d "Create patch for head and scp it"
+  git show HEAD -U999999 > /tmp/head.patch
+  scp /tmp/patch "$argv":/tmp/head.patch
+end

--- a/.gitconfig
+++ b/.gitconfig
@@ -42,6 +42,7 @@
 	fmt = clang-format
 	git = "!exec git"
 	graph = log --graph --color --pretty=format:"%C(yellow)%H%C(green)%d%C(reset)%n%x20%cd%n%x20%cn%x20(%ce)%n%x20%s%n"
+	hist = log -p -M --follow --stat
 	lg = log -p
 	ll = log --stat
 	patch =  show HEAD -U999999

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,6 +22,9 @@ bind-key C-a send-prefix
 # Support 256 colors
 set -g default-terminal "screen-256color"
 
+# Integrate with OS X pasteboard.
+set -g default-command "reattach-to-user-namespace -l fish"
+
 # Automatically rename window
 set-window-option -g automatic-rename
 setw -g automatic-rename

--- a/.vim/.ycm_extra_conf.py
+++ b/.vim/.ycm_extra_conf.py
@@ -122,7 +122,7 @@ def FlagsForClangComplete(root):
     try:
         clang_complete_path = FindNearest(root, '.clang_complete')
         clang_complete_flags = open(clang_complete_path, 'r').read().splitlines()
-        return clang_complete_flags
+        return clang_complete_flags, clang_complete_path
     except:
         return None
 
@@ -166,7 +166,7 @@ def FlagsForFile(filename):
         final_flags = compilation_db_flags
     else:
         final_flags = BASE_FLAGS
-        clang_flags = FlagsForClangComplete(root)
+        clang_flags, clang_path = FlagsForClangComplete(root)
         if clang_flags:
             final_flags = final_flags + clang_flags
         include_flags = FlagsForInclude(root)
@@ -174,5 +174,6 @@ def FlagsForFile(filename):
             final_flags = final_flags + include_flags
     return {
             'flags': final_flags,
+            'include_paths_relative_to_dir': os.path.dirname(os.path.abspath(clang_path)),
             'do_cache': True
             }

--- a/.vim/.ycm_extra_conf.py
+++ b/.vim/.ycm_extra_conf.py
@@ -183,6 +183,7 @@ def FlagsForCompilationDatabase(root, filename):
 def FlagsForFile(filename):
     root = os.path.realpath(filename);
     compilation_db_flags = FlagsForCompilationDatabase(root, filename)
+    final_flags = []
     if compilation_db_flags:
         final_flags = compilation_db_flags
     else:

--- a/.vim/.ycm_extra_conf.py
+++ b/.vim/.ycm_extra_conf.py
@@ -143,7 +143,7 @@ def FlagsForClangComplete(root):
     try:
         clang_complete_path = FindNearest(root, '.clang_complete')
         clang_complete_flags = open(clang_complete_path, 'r').read().splitlines()
-        return clang_complete_flags
+        return clang_complete_flags, clang_complete_path
     except:
         return None
 
@@ -193,7 +193,7 @@ def FlagsForFile(filename):
             else:
                 final_flags = CPP_BASE_FLAGS
 
-        clang_flags = FlagsForClangComplete(root)
+        clang_flags, clang_path = FlagsForClangComplete(root)
         if clang_flags:
             final_flags = final_flags + clang_flags
         include_flags = FlagsForInclude(root)
@@ -201,5 +201,6 @@ def FlagsForFile(filename):
             final_flags = final_flags + include_flags
     return {
             'flags': final_flags,
+            'include_paths_relative_to_dir': os.path.dirname(os.path.abspath(clang_path)),
             'do_cache': True
             }

--- a/.vim/.ycm_extra_conf.py
+++ b/.vim/.ycm_extra_conf.py
@@ -5,7 +5,21 @@ import logging
 import ycm_core
 import re
 
-BASE_FLAGS = [
+C_BASE_FLAGS = [
+        '-Wall',
+        '-Wextra',
+        '-Werror',
+        '-Wno-long-long',
+        '-Wno-variadic-macros',
+        '-fexceptions',
+        '-ferror-limit=10000',
+        '-DNDEBUG',
+        '-std=c11',
+        '-I/usr/lib/',
+        '-I/usr/include/'
+        ]
+
+CPP_BASE_FLAGS = [
         '-Wall',
         '-Wextra',
         '-Wno-long-long',
@@ -19,11 +33,14 @@ BASE_FLAGS = [
         '-I/usr/include/'
         ]
 
-SOURCE_EXTENSIONS = [
+C_SOURCE_EXTENSIONS = [
+        '.c'
+        ]
+
+CPP_SOURCE_EXTENSIONS = [
         '.cpp',
         '.cxx',
         '.cc',
-        '.c',
         '.m',
         '.mm'
         ]
@@ -46,6 +63,10 @@ HEADER_DIRECTORIES = [
 
 BUILD_DIRECTORY = 'build';
 
+def IsSourceFile(filename):
+    extension = os.path.splitext(filename)[1]
+    return extension in C_SOURCE_EXTENSIONS + CPP_SOURCE_EXTENSIONS
+
 def IsHeaderFile(filename):
     extension = os.path.splitext(filename)[1]
     return extension in HEADER_EXTENSIONS
@@ -53,7 +74,7 @@ def IsHeaderFile(filename):
 def GetCompilationInfoForFile(database, filename):
     if IsHeaderFile(filename):
         basename = os.path.splitext(filename)[0]
-        for extension in SOURCE_EXTENSIONS:
+        for extension in C_SOURCE_EXTENSIONS + CPP_SOURCE_EXTENSIONS:
             # Get info from the source files by replacing the extension.
             replacement_file = basename + extension
             if os.path.exists(replacement_file):
@@ -165,7 +186,13 @@ def FlagsForFile(filename):
     if compilation_db_flags:
         final_flags = compilation_db_flags
     else:
-        final_flags = BASE_FLAGS
+        if IsSourceFile(filename):
+            extension = os.path.splitext(filename)[1]
+            if extension in C_SOURCE_EXTENSIONS:
+                final_flags = C_BASE_FLAGS
+            else:
+                final_flags = CPP_BASE_FLAGS
+
         clang_flags = FlagsForClangComplete(root)
         if clang_flags:
             final_flags = final_flags + clang_flags

--- a/.vimrc
+++ b/.vimrc
@@ -27,6 +27,7 @@ Plug 'ajh17/vimcompletesme'
 
 Plug 'chiel92/vim-autoformat',              { 'on': 'Autoformat' }
 Plug 'majutsushi/tagbar',                   { 'on': 'TagbarToggle' }
+Plug 'scrooloose/nerdtree',                 { 'on': ['NERDTreeFind', 'NERDTreeToggle'] }
 
 Plug 'vim-scripts/doxygentoolkit.vim',      { 'for': 'cpp' }
 Plug 'octol/vim-cpp-enhanced-highlight',    { 'for': 'cpp' }
@@ -323,6 +324,34 @@ let g:tagbar_compact=1
 let g:tagbar_right=1
 let g:tagbar_width=35
 nnoremap <leader>tt :TagbarToggle<CR>
+
+" nerdtree
+let g:NERDTreeAutoDeleteBuffer=1
+let g:NERDTreeIgnore=['\.job$', '^CVS$', '\.orig', '\~$']
+let g:NERDTreeMinimalUI=1
+let g:NERDTreeQuitOnOpen=1
+let g:NERDTreeShowHidden=1
+let g:NERDTreeWinPos="left"
+let g:NERDTreeWinSize=35
+
+nnoremap <leader>tn :NERDTreeToggle<CR>
+
+function! SyncNerdTree()
+    if exists("t:NERDTreeBufName")
+      NERDTreeFind
+      wincmd p
+    endif
+endfunction
+
+augroup nerdtree_close
+    autocmd!
+    autocmd BufEnter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+augroup end
+
+augroup nerdtree_find
+    autocmd!
+    autocmd BufReadPost * call SyncNerdTree()
+augroup end
 
 " vim-autoformat
 let g:formatters_python=['yapf', 'autopep8']

--- a/.vimrc
+++ b/.vimrc
@@ -231,6 +231,7 @@ nnoremap <leader>yl :let @+=expand('%:t') . ':' . line(".")<CR>
 " Toggle
 nnoremap <leader>ts :setlocal spell!<CR>
 nnoremap <leader>tl :set list!<CR>
+nnoremap <leader>tw :call ToggleRemoveTrailingWhitespace()<CR>
 
 " Buffers
 nnoremap <leader>bd :bdelete<CR>
@@ -242,6 +243,26 @@ nnoremap <leader>bp :bprevious<CR>
 " Windows
 nnoremap <leader>wd <C-w>c
 nnoremap <leader>wo <C-w>o
+
+" ---------------------------------------------------------------------------- "
+" Functions                                                                    "
+" ---------------------------------------------------------------------------- "
+
+function! ToggleRemoveTrailingWhitespace()
+  if exists("g:dont_remove_trailing_whitespace")
+    unlet g:dont_remove_trailing_whitespace
+    echo "Disabled removing trailing whitespace"
+  else
+    let g:dont_remove_trailing_whitespace=1
+    echo "Enabled removing trailing whitespace"
+  endif
+endfunction
+
+function! RemoveTrailingWhitespace()
+  if !exists("g:dont_remove_trailing_whitespace")
+    %s/\s\+$//e
+  endif
+endfunction
 
 " ---------------------------------------------------------------------------- "
 " Auto Commands                                                                "
@@ -264,7 +285,7 @@ augroup end
 " Remove trailing whitespace
 augroup remove_trailing_whitespace
     autocmd!
-    autocmd BufWritePre * :%s/\s\+$//e
+    autocmd BufWritePre * :call RemoveTrailingWhitespace()
 augroup end
 
 " Watch my .vimrc

--- a/.vimrc
+++ b/.vimrc
@@ -190,9 +190,10 @@ highlight TabLineSel   ctermfg=White  ctermbg=DarkBlue  cterm=NONE
 " ---------------------------------------------------------------------------- "
 
 " Typos
-cnoreabbrev W w
+cnoreabbrev E e
 cnoreabbrev Q q
 cnoreabbrev Qa qa
+cnoreabbrev W w
 
 " Save file which you forgot to open with sudo
 cnoremap w!! w !sudo tee % >/dev/null

--- a/.vimrc
+++ b/.vimrc
@@ -251,10 +251,10 @@ nnoremap <leader>wo <C-w>o
 function! ToggleRemoveTrailingWhitespace()
   if exists("g:dont_remove_trailing_whitespace")
     unlet g:dont_remove_trailing_whitespace
-    echo "Disabled removing trailing whitespace"
+    echo "Enabled removing trailing whitespace"
   else
     let g:dont_remove_trailing_whitespace=1
-    echo "Enabled removing trailing whitespace"
+    echo "Disabled removing trailing whitespace"
   endif
 endfunction
 

--- a/.vimrc
+++ b/.vimrc
@@ -15,6 +15,7 @@ Plug 'junegunn/fzf',                        { 'do': 'yes \| ./install' }
 Plug 'junegunn/fzf.vim'
 Plug 'mhinz/vim-signify'
 Plug 'moll/vim-bbye'
+Plug 'ryanoasis/vim-devicons'
 Plug 'shougo/vimproc',                      { 'do': 'make' }
 Plug 'tpope/vim-commentary'
 Plug 'tpope/vim-fugitive'
@@ -293,7 +294,19 @@ nnoremap <silent> <C-b> :Buffers<CR>
 " vim-lightline
 let g:lightline = {
       \ 'colorscheme': 'solarized',
+      \ 'component_function': {
+      \   'filetype': 'MyFiletype',
+      \   'fileformat': 'MyFileformat',
       \ }
+      \ }
+
+function! MyFiletype()
+  return winwidth(0) > 70 ? (strlen(&filetype) ? &filetype . ' ' . WebDevIconsGetFileTypeSymbol() : 'no ft') : ''
+endfunction
+
+function! MyFileformat()
+  return winwidth(0) > 70 ? (&fileformat . ' ' . WebDevIconsGetFileFormatSymbol()) : ''
+endfunction
 
 " detectindent
 let g:detectindent_preferred_expandtab=1

--- a/os/macos.sh
+++ b/os/macos.sh
@@ -31,6 +31,9 @@ defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 defaults write -g InitialKeyRepeat -int 10
 defaults write -g KeyRepeat -int 1
 
+# Disable mouse accelerator.
+defaults write .GlobalPreferences com.apple.mouse.scaling -1
+
 # Set language and text formats
 defaults write NSGlobalDomain AppleLanguages -array "en" "nl"
 defaults write NSGlobalDomain AppleLocale -string "en_US@currency=EUR"

--- a/scripts/apt.sh
+++ b/scripts/apt.sh
@@ -100,7 +100,7 @@ if [ -n "$1" ]; then
             --enable-perlinterp \
             --enable-luainterp \
             --enable-gui=gtk2 --enable-cscope --prefix=/usr
-        make -j VIMRUNTIMEDIR=/usr/share/vim/vim80
+        make -j VIMRUNTIMEDIR=/usr/share/vim/vim81
         sudo make install
 
         sudo update-alternatives --install /usr/bin/editor editor /usr/bin/vim 1

--- a/scripts/apt.sh
+++ b/scripts/apt.sh
@@ -54,6 +54,7 @@ if [ -n "$1" ]; then
         libbonoboui2-dev \
         libboost-all-dev \
         libcairo2-dev \
+        libedit-dev \
         libgnome2-dev \
         libgnomeui-dev \
         libgtk2.0-dev \
@@ -65,7 +66,10 @@ if [ -n "$1" ]; then
         libxpm-dev \
         libxt-dev \
         python-dev \
+        python2.7-dev \
         ruby-dev \
+        subversion \
+        swig \
         uuid-dev
 
     # OpenVPN

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -57,6 +57,7 @@ installEssentials() {
 	brew install pandoc
 	brew install python
 	brew install re2c
+	brew install reattach-to-user-namespace
 	brew install ripgrep
 	brew install rsync
 	brew install the_silver_searcher

--- a/scripts/llvm-mono.sh
+++ b/scripts/llvm-mono.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GIT_SVN_DIR
 
 
 # Clone
-git clone https://github.com/llvm-project/llvm-project-20170507/ llvm-project
+git clone https://github.com/llvm-git-prototype/llvm.git llvm-project
 
 # Configure repo
 cd llvm-project || exit 1

--- a/scripts/swift.sh
+++ b/scripts/swift.sh
@@ -1,62 +1,7 @@
 #!/usr/bin/env bash
 
-# Clones swift in the current directory.
-# .
-# ├── build
-# ├── clang
-# ├── cmark
-# ├── llvm
-# └── swift
+# Clone the swift repository.
+git clone git@github.com:apple/swift.git
 
-export SWIFT_SOURCE_ROOT=$(pwd)
-export SWIFT_BUILD_ROOT=$(pwd)/build
-
-SWIFT_CLANG_ROOT=$SWIFT_SOURCE_ROOT/clang
-SWIFT_CMARK_ROOT=$SWIFT_SOURCE_ROOT/cmark
-SWIFT_LLDB_ROOT=$SWIFT_SOURCE_ROOT/lldb
-SWIFT_LLVM_ROOT=$SWIFT_SOURCE_ROOT/llvm
-SWIFT_SWIFT_ROOT=$SWIFT_SOURCE_ROOT/swift
-SWIFT_SWIFTPM_ROOT=$SWIFT_SOURCE_ROOT/swiftpm
-SWIFT_LLBUILD_ROOT=$SWIFT_SOURCE_ROOT/llbuild
-
-info() {
-  printf "\033[00;34m$@\033[0m\n"
-}
-
-cd "$SWIFT_SOURCE_ROOT" || exit
-
-info "Cloning repositories"
-
-git clone git@github.com:apple/swift-clang.git "$SWIFT_CLANG_ROOT" &> /dev/null &
-git clone git@github.com:apple/swift-cmark.git "$SWIFT_CMARK_ROOT" &> /dev/null &
-git clone git@github.com:apple/swift-lldb.git "$SWIFT_LLDB_ROOT" &> /dev/null &
-git clone git@github.com:apple/swift-llvm.git "$SWIFT_LLVM_ROOT" &> /dev/null &
-git clone git@github.com:apple/swift.git "$SWIFT_SWIFT_ROOT" &> /dev/null &
-
-git clone git@github.com:apple/swift-package-manager.git "$SWIFT_SWIFTPM_ROOT" &> /dev/null &
-git clone git@github.com:apple/swift-llbuild.git "$SWIFT_LLBUILD_ROOT" &> /dev/null &
-
-git clone git@github.com:apple/swift-corelibs-foundation.git &> /dev/null &
-git clone git@github.com:apple/swift-corelibs-libdispatch.git &> /dev/null &
-git clone git@github.com:apple/swift-corelibs-xctest.git &> /dev/null &
-
-wait
-
-info "Adding upstream remotes"
-
-cd "$SWIFT_CLANG_ROOT" || exit
-git remote add upstream https://git.llvm.org/git/clang.git
-
-cd "$SWIFT_LLDB_ROOT" || exit
-git remote add upstream https://git.llvm.org/git/lldb.git
-
-cd "$SWIFT_LLVM_ROOT" || exit
-git remote add upstream https://git.llvm.org/git/llvm.git
-
-info "Updating checkout"
-"$SWIFT_SWIFT_ROOT/utils/update-checkout" --scheme=master --reset-to-remote
-
-if [ $# -ne 0 ]; then
-  info "Invoking build script"
-  "$SWIFT_SWIFT_ROOT/utils/build-script" "$@"
-fi
+# Use the update-checkout script to clone everyting else.
+python swift/utils/update-checkout --scheme master --clone-with-ssh

--- a/scripts/swift.sh
+++ b/scripts/swift.sh
@@ -42,6 +42,17 @@ git clone git@github.com:apple/swift-corelibs-xctest.git &> /dev/null &
 
 wait
 
+info "Adding upstream remotes"
+
+cd "$SWIFT_CLANG_ROOT" || exit
+git remote add upstream https://git.llvm.org/git/clang.git
+
+cd "$SWIFT_LLDB_ROOT" || exit
+git remote add upstream https://git.llvm.org/git/lldb.git
+
+cd "$SWIFT_LLVM_ROOT" || exit
+git remote add upstream https://git.llvm.org/git/llvm.git
+
 info "Updating checkout"
 "$SWIFT_SWIFT_ROOT/utils/update-checkout" --scheme=master --reset-to-remote
 


### PR DESCRIPTION
# Issue

for some complex project structure:

```
~/
    ModuleA/
        src/
        .clang_complete (A)
    src/
    .clang_complete (root)
```

when editing source files under ModuleA, the `.clang_complete (A)` would be used,
if it contains relative path, it would result to wrong abs path since PWD is `~`

# Solution

YCM support `include_paths_relative_to_dir` to specify the working dir